### PR TITLE
[SIMP-1446] Prevent log duplication and log where intended

### DIFF
--- a/manifests/dhcpd.pp
+++ b/manifests/dhcpd.pp
@@ -82,7 +82,7 @@ class dhcp::dhcpd (
     notify   => Service['dhcpd']
   }
 
-  rsyslog::rule::local { '10dhcpd':
+  rsyslog::rule::local { 'XX_dhcpd':
     rule            => 'if ($programname == \'dhcpd\') then',
     target_log_file => '/var/log/dhcpd.log',
     stop_processing => true


### PR DESCRIPTION
Related to changes in default rsyslog rule naming in https://simp-project.atlassian.net/browse/SIMP-1446
