### PR TITLE
(SIMP-1692) Point fixtures to `5.X` branches

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,23 +1,41 @@
 ---
 fixtures:
   repositories:
-    auditd: "https://github.com/simp/pupmod-simp-auditd"
-    augeasproviders_core: 
-      repo: "https://github.com/simp/augeasproviders_core"
-      branch: "simp-master"
-    augeasproviders_grub: 
-      repo: "https://github.com/simp/augeasproviders_grub"
-      branch: "simp-master"
-    compliance_markup: "https://github.com/simp/pupmod-simp-compliance_markup"
-    iptables: "https://github.com/simp/pupmod-simp-iptables"
-    logrotate: "https://github.com/simp/pupmod-simp-logrotate"
-    pki: "https://github.com/simp/pupmod-simp-pki"
-    rsync: "https://github.com/simp/pupmod-simp-rsync"
-    rsyslog: "https://github.com/simp/pupmod-simp-rsyslog"
-    simplib: "https://github.com/simp/pupmod-simp-simplib"
-    simpcat: "https://github.com/simp/pupmod-simp-simpcat"
-    stdlib: 
-      repo: "https://github.com/simp/puppetlabs-stdlib"
-      branch: "simp-master"
+    auditd:
+      repo: https://github.com/simp/pupmod-simp-auditd
+      branch: 5.X
+    augeasproviders_core:
+      branch: 5.X
+      repo: https://github.com/simp/augeasproviders_core
+    augeasproviders_grub:
+      branch: 5.X
+      repo: https://github.com/simp/augeasproviders_grub
+    compliance_markup:
+      repo: https://github.com/simp/pupmod-simp-compliance_markup
+      branch: 5.X
+    iptables:
+      repo: https://github.com/simp/pupmod-simp-iptables
+      branch: 5.X
+    logrotate:
+      repo: https://github.com/simp/pupmod-simp-logrotate
+      branch: 5.X
+    pki:
+      repo: https://github.com/simp/pupmod-simp-pki
+      branch: 5.X
+    rsync:
+      repo: https://github.com/simp/pupmod-simp-rsync
+      branch: 5.X
+    rsyslog:
+      repo: https://github.com/simp/pupmod-simp-rsyslog
+      branch: 5.X
+    simplib:
+      repo: https://github.com/simp/pupmod-simp-simplib
+      branch: 5.X
+    simpcat:
+      repo: https://github.com/simp/pupmod-simp-simpcat
+      branch: 5.X
+    stdlib:
+      branch: 5.X
+      repo: https://github.com/simp/puppetlabs-stdlib
   symlinks:
     dhcp: "#{source_dir}"


### PR DESCRIPTION
This commit marks the transition of mainline SIMP development away from
4.x/5.x.  From this point on, the `master` branch will be used to target SIMP
6.x.

This commit updates `fixtures.yml` to reference the newly-created `5.X` branch
in each `simp/` repository.

SIMP-1692 #comment updated `.fixtures.yml` in dhcp