### PR TITLE
(SIMP-2221) Prevent log duplication and log where intended

### DIFF
--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -2,3 +2,4 @@
 --relative
 --no-class_inherits_from_params_class-check
 --no-80chars-check
+--no-trailing_comma-check

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+* Thu Dec 01 2016 Nicholas Hughes, Nick Markowski <nmarkowski@keywcorp.com> - 5.0.1-0
+- Prevent log duplication and log where intended.
+- Changed naming to XX_ or YY_ to come before the default Z_default.conf
+  for local rules, but after the numbered configs used by the log_server
+  class.
+
 * Tue Nov 22 2016 Liz Nemsick <lnemsick.simp@gmail.com> - 5.0.0-0
 - Update version to reflect SIMP6 dependencies
 - Update SIMP6 dependencies

--- a/manifests/dhcpd.pp
+++ b/manifests/dhcpd.pp
@@ -82,7 +82,7 @@ class dhcp::dhcpd (
     notify   => Service['dhcpd']
   }
 
-  rsyslog::rule::local { '10dhcpd':
+  rsyslog::rule::local { 'XX_dhcpd':
     rule            => 'if ($programname == \'dhcpd\') then',
     target_log_file => '/var/log/dhcpd.log',
     stop_processing => true

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-dhcp",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "author": "SIMP Team",
   "summary": "A Puppet module to automate configuration of DHCP",
   "license": "Apache-2.0",

--- a/spec/classes/dhcpd_spec.rb
+++ b/spec/classes/dhcpd_spec.rb
@@ -38,6 +38,8 @@ describe 'dhcp::dhcpd' do
               :require => ['File[/etc/dhcpd.conf]', 'Package[dhcp]']
             })
           }
+
+          it { is_expected.to contain_rsyslog__rule__local ( 'XX_dhcpd' ) }
         end
       end
     end


### PR DESCRIPTION
- Changed naming to XX_ or YY_ to come before the default Z_default.conf
  for local rules, but after the numbered configs used by the log_server
  class.

SIMP-2221 #close
SIMP-1446 #comment related to changes in log_server