### PR TITLE
(SIMP-3372) dhcp - deps/changelog cleanup as prep for tagging

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 * Wed Apr 19 2017 Nick Markowski <nmarkowski@keywcorp.com> - 6.0.1-0
 - Updated logrotate to use new lastaction API
+- Confine puppet version in metadata.json
 
 * Mon Jan 23 2017 Nick Markowski <nmarkowski@keywcorp.com> - 6.0.0-0
 - Calls to rsyslog::rule no longer contain logic

--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -4,7 +4,7 @@ Requires: pupmod-puppetlabs-stdlib >= 4.13.1-0
 Requires: pupmod-simp-iptables < 7.0.0-0
 Requires: pupmod-simp-iptables >= 6.0.0-0
 Requires: pupmod-simp-logrotate < 7.0.0-0
-Requires: pupmod-simp-logrotate >= 6.0.0-0
+Requires: pupmod-simp-logrotate >= 6.1.0-0
 Requires: pupmod-simp-rsync >= 6.0.0-0
 Requires: pupmod-simp-rsync < 7.0.0-0
 Requires: pupmod-simp-rsyslog < 8.0.0-0

--- a/metadata.json
+++ b/metadata.json
@@ -26,7 +26,7 @@
     },
     {
       "name": "simp/logrotate",
-      "version_requirement": ">= 6.0.0 < 7.0.0"
+      "version_requirement": ">= 6.1.0 < 7.0.0"
     },
     {
       "name": "simp/rsyslog",

--- a/spec/classes/dhcpd_spec.rb
+++ b/spec/classes/dhcpd_spec.rb
@@ -7,12 +7,12 @@ describe 'dhcp::dhcpd' do
   context 'supported operating systems' do
     on_supported_os.each do |os, facts|
       context "on #{os}" do
-        let(:environment){:foo}
+        let(:environment){'foo'}
         let(:facts) do
           facts
         end
 
-        context 'in the :foo environment' do
+        context 'in the foo environment' do
           it { is_expected.to create_class('dhcp::dhcpd') }
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to contain_package('dhcp').with_ensure('latest') }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -8,8 +8,8 @@ describe 'dhcp' do
       end
 
       context "on #{os}" do
-        context 'in the :foo environment' do
-          let(:environment){:foo}
+        context 'in the foo environment' do
+          let(:environment){'foo'}
 
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to contain_class('dhcp::dhcpd') }


### PR DESCRIPTION
Requires newer version of logrotate.
Fix for latest rspec-puppet