### PR TITLE
(SIMP-6110) Use (namespaced) simplib::passgen

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ addons:
 
 before_install:
   - rm -f Gemfile.lock
+  - gem install -v '~> 1.17' bundler
 
 global:
   - STRICT_VARIABLES=yes

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Tue Feb 12 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 6.1.1-0
+- Use simplib::passgen() in lieu of passgen(), a deprecated simplib
+  Puppet 3 function.
+
 * Mon Oct 15 2018 Nick Miller <nick.miller@onyxpoint.com> - 6.1.0-0
 - Added $dhcp::dhcpd::package_ensure parameter
   - Changed the package from 'latest' to 'installed'

--- a/manifests/dhcpd.pp
+++ b/manifests/dhcpd.pp
@@ -71,7 +71,7 @@ class dhcp::dhcpd (
   $_downcase_os_name = downcase($facts['os']['name'])
   rsync { 'dhcpd':
     user     => "dhcpd_rsync_${::environment}_${_downcase_os_name}",
-    password => passgen("dhcpd_rsync_${::environment}_${_downcase_os_name}"),
+    password => simplib::passgen("dhcpd_rsync_${::environment}_${_downcase_os_name}"),
     server   => $rsync_server,
     timeout  => $rsync_timeout,
     source   => $rsync_source,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-dhcp",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "author": "SIMP Team",
   "summary": "A Puppet module to automate configuration of DHCP",
   "license": "Apache-2.0",
@@ -22,7 +22,7 @@
     },
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 3.1.0 < 4.0.0"
+      "version_requirement": ">= 3.5.0 < 4.0.0"
     },
     {
       "name": "simp/logrotate",


### PR DESCRIPTION
Use simplib::passgen() in lieu of passgen(), a deprecated simplib
Puppet 3 function.

SIMP-6110 #comment pupmod-simp-dhcp