### PR TITLE
(SIMP-6229) Update upper bound stdlib < 6.0.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 * Tue Feb 12 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 6.1.1-0
 - Use simplib::passgen() in lieu of passgen(), a deprecated simplib
   Puppet 3 function.
+- Update the upper bound of stdlib to < 6.0.0
+- Update a URL in the README.md
 
 * Mon Oct 15 2018 Nick Miller <nick.miller@onyxpoint.com> - 6.1.0-0
 - Added $dhcp::dhcpd::package_ensure parameter

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ a compliance-management framework built on Puppet.
 
 If you find any issues, they can be submitted to our [JIRA](https://simp-project.atlassian.net/).
 
-Please read our [Contribution Guide](http://simp-doc.readthedocs.io/en/stable/contributors_guide/index.html).
+Please read our [Contribution Guide](https://simp.readthedocs.io/en/stable/contributors_guide/index.html).
 
 ## Work in Progress
 

--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 5.0.0"
+      "version_requirement": ">= 4.13.1 < 6.0.0"
     },
     {
       "name": "simp/iptables",


### PR DESCRIPTION
- Update the upper bound of stdlib to < 6.0.0
- Update a URL in the README.md

SIMP-6229 #comment pupmod-simp-dhcp