### PR TITLE
Add RockyLinux 8 support

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -109,14 +109,16 @@ jobs:
     strategy:
       matrix:
         puppet:
-          - label: 'Puppet 7.x'
-            puppet_version: '~> 7.21.0'
+          - label: 'Puppet 7.x [SIMP 6.6/PE 2021.7]'
+            puppet_version: '~> 7.0'
             ruby_version: '2.7'
+            experimental: false
           - label: 'Puppet 8.x'
             puppet_version: '~> 8.0'
-            ruby_version: '3.2'
+            ruby_version: 3.1
+            experimental: true
     env:
-      PUPPET_VERSION: '${{matrix.puppet.puppet_version}}'
+      PUPPET_VERSION: ${{matrix.puppet.puppet_version}}
     steps:
       - uses: actions/checkout@v3
       - name: 'Install Ruby ${{matrix.puppet.ruby_version}}'
@@ -126,6 +128,7 @@ jobs:
           bundler-cache: true
       - run: 'command -v rpm || if command -v apt-get; then sudo apt-get update; sudo apt-get install -y rpm; fi ||:'
       - run: 'bundle exec rake spec'
+        continue-on-error: ${{matrix.puppet.experimental}}
 
 #  dump_contexts:
 #    name: 'Examine Context contents'

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -9,7 +9,7 @@
 --no-class_inherits_from_params_class-check
 --no-140chars-check
 --no-trailing_comma-check
---no-empty_string_assignment-check
+--no-params-empty-string-assignment-check
 # This is here because the code can't handle lookups in parameters and SIMP
 # modules have a LOT of those
 --no-parameter_order-check

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Mon Jun 12 2023 Chris Tessmer <chris.tessmer@onyxpoint.com> - 6.4.0
+- Add RockyLinux 8 support
+
 * Sun Jul 17 2022 Trevor Vaughan <trevor@sicura.us> - 6.3.1
 - Support Amazon Linux 2
 

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ group :test do
   gem 'puppetlabs_spec_helper'
   gem 'metadata-json-lint'
   gem 'puppet-strings'
-  gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
   gem 'simp-rspec-puppet-facts', ENV['SIMP_RSPEC_PUPPET_FACTS_VERSION'] || '~> 3.1'
   gem 'simp-rake-helpers', ENV['SIMP_RAKE_HELPERS_VERSION'] || ['>= 5.12.1', '< 6']

--- a/manifests/dhcpd.pp
+++ b/manifests/dhcpd.pp
@@ -37,7 +37,7 @@ class dhcp::dhcpd (
   String[1]               $package_name, # In module data
   Optional[String[1]]     $dhcpd_conf        = undef,
   Boolean                 $enable_data_rsync = true,
-  String[1]               $rsync_source      = "dhcpd_${::environment}_${facts['os']['name']}/dhcpd.conf",
+  String[1]               $rsync_source      = "dhcpd_${facts['environment']}_${facts['os']['name']}/dhcpd.conf",
   String[1]               $rsync_server      = simplib::lookup('simp_options::rsync::server', { 'default_value' => '127.0.0.1' }),
   Stdlib::Compat::Integer $rsync_timeout     = simplib::lookup('simp_options::rsync::timeout', { 'default_value' => '2' }),
   Boolean                 $firewall          = simplib::lookup('simp_options::firewall', { 'default_value' => false }),
@@ -123,8 +123,8 @@ class dhcp::dhcpd (
 
     $_downcase_os_name = downcase($facts['os']['name'])
     rsync { 'dhcpd':
-      user      => "dhcpd_rsync_${::environment}_${_downcase_os_name}",
-      password  => simplib::passgen("dhcpd_rsync_${::environment}_${_downcase_os_name}"),
+      user      => "dhcpd_rsync_${facts['environment']}_${_downcase_os_name}",
+      password  => simplib::passgen("dhcpd_rsync_${facts['environment']}_${_downcase_os_name}"),
       server    => $rsync_server,
       timeout   => $rsync_timeout,
       source    => $rsync_source,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-dhcp",
-  "version": "6.3.1",
+  "version": "6.4.0",
   "author": "SIMP Team",
   "summary": "A Puppet module to automate configuration of DHCP",
   "license": "Apache-2.0",
@@ -14,7 +14,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 6.6.0 < 8.0.0"
+      "version_requirement": ">= 8.0.0 < 9.0.0"
     },
     {
       "name": "simp/iptables",
@@ -63,6 +63,12 @@
       "operatingsystemrelease": [
         "8",
         "7"
+      ]
+    },
+    {
+      "operatingsystem": "Rocky",
+      "operatingsystemrelease": [
+        "8"
       ]
     }
   ],


### PR DESCRIPTION
This patch adds support for RockyLinux 8

The patch enforces a standardized asset baseline using simp/puppetsync,
and may also apply other updates to ensure conformity.