### PR TITLE
Support for Puppet 8 and stdlib 9

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+* Tue Aug 29 2023 Steven Pritchard <steve@sicura.us> - 6.5.0
+- Support for Puppet 8 and stdlib 9
+- Drop use of Stdlib::Compat::Integer type
+- Drop use of deprecated top-level facts
+- Update gem dependencies
+- Drop support for Puppet 6
+
 * Mon Jun 12 2023 Chris Tessmer <chris.tessmer@onyxpoint.com> - 6.4.0
 - Add RockyLinux 8 support
 

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ ENV['PDK_DISABLE_ANALYTICS'] ||= 'true'
 gem_sources.each { |gem_source| source gem_source }
 
 group :test do
-  puppet_version = ENV['PUPPET_VERSION'] || '~> 7'
+  puppet_version = ENV['PUPPET_VERSION'] || '~> 8'
   major_puppet_version = puppet_version.scan(/(\d+)(?:\.|\Z)/).flatten.first.to_i
   gem 'rake'
   gem 'puppet', puppet_version
@@ -22,9 +22,9 @@ group :test do
   gem 'metadata-json-lint'
   gem 'puppet-strings'
   gem 'puppet-lint-trailing_comma-check', :require => false
-  gem 'simp-rspec-puppet-facts', ENV['SIMP_RSPEC_PUPPET_FACTS_VERSION'] || '~> 3.1'
-  gem 'simp-rake-helpers', ENV['SIMP_RAKE_HELPERS_VERSION'] || ['>= 5.12.1', '< 6']
-  gem( 'pdk', ENV['PDK_VERSION'] || '~> 2.0', :require => false) if major_puppet_version > 5
+  gem 'simp-rspec-puppet-facts', ENV['SIMP_RSPEC_PUPPET_FACTS_VERSION'] || '~> 3.7'
+  gem 'simp-rake-helpers', ENV['SIMP_RAKE_HELPERS_VERSION'] || ['>= 5.21.0', '< 6']
+  gem( 'pdk', ENV['PDK_VERSION'] || ['>= 2.0', '< 4.0'], :require => false) if major_puppet_version > 5
   gem 'pathspec', '~> 0.2' if Gem::Requirement.create('< 2.6').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
 end
 
@@ -37,7 +37,7 @@ end
 group :system_tests do
   gem 'beaker'
   gem 'beaker-rspec'
-  gem 'simp-beaker-helpers', ENV['SIMP_BEAKER_HELPERS_VERSION'] || ['>= 1.28.0', '< 2']
+  gem 'simp-beaker-helpers', ENV['SIMP_BEAKER_HELPERS_VERSION'] || ['>= 1.32.1', '< 2']
   gem 'bcrypt_pbkdf'
 end
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -84,7 +84,14 @@ Default value: `simplib::lookup('simp_options::rsync::server', { 'default_value'
 
 ##### <a name="-dhcp--dhcpd--rsync_timeout"></a>`rsync_timeout`
 
-Data type: `Stdlib::Compat::Integer`
+Data type:
+
+```puppet
+Variant[
+    Integer[0],
+    Pattern[/\A\d+\z/]
+  ]
+```
 
 The connection timeout when communicating with the rsync server
 

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -5,9 +5,9 @@ defaults:
   data_hash: yaml_data
 hierarchy:
   - name: "OS + Release"
-    path: "os/%{facts.operatingsystem}-%{facts.operatingsystemmajrelease}.yaml"
+    path: "os/%{facts.os.name}-%{facts.os.release.major}.yaml"
   - name: "OS"
-    path: "os/%{facts.operatingsystem}.yaml"
+    path: "os/%{facts.os.name}.yaml"
   - name: "Kernel"
     path: "os/%{facts.kernel}.yaml"
   - name: "Common"

--- a/manifests/dhcpd.pp
+++ b/manifests/dhcpd.pp
@@ -34,16 +34,19 @@
 # @author https://github.com/simp/pupmod-simp-dhcp/graphs/contributors
 #
 class dhcp::dhcpd (
-  String[1]               $package_name, # In module data
-  Optional[String[1]]     $dhcpd_conf        = undef,
-  Boolean                 $enable_data_rsync = true,
-  String[1]               $rsync_source      = "dhcpd_${facts['environment']}_${facts['os']['name']}/dhcpd.conf",
-  String[1]               $rsync_server      = simplib::lookup('simp_options::rsync::server', { 'default_value' => '127.0.0.1' }),
-  Stdlib::Compat::Integer $rsync_timeout     = simplib::lookup('simp_options::rsync::timeout', { 'default_value' => '2' }),
-  Boolean                 $firewall          = simplib::lookup('simp_options::firewall', { 'default_value' => false }),
-  Boolean                 $logrotate         = simplib::lookup('simp_options::logrotate', { 'default_value' => false }),
-  Boolean                 $syslog            = simplib::lookup('simp_options::syslog', { 'default_value' => false }),
-  String[1]               $package_ensure    = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' })
+  String[1]            $package_name, # In module data
+  Optional[String[1]]  $dhcpd_conf        = undef,
+  Boolean              $enable_data_rsync = true,
+  String[1]            $rsync_source      = "dhcpd_${facts['environment']}_${facts['os']['name']}/dhcpd.conf",
+  String[1]            $rsync_server      = simplib::lookup('simp_options::rsync::server', { 'default_value' => '127.0.0.1' }),
+  Variant[
+    Integer[0],
+    Pattern[/\A\d+\z/]
+  ]                    $rsync_timeout     = simplib::lookup('simp_options::rsync::timeout', { 'default_value' => '2' }),
+  Boolean              $firewall          = simplib::lookup('simp_options::firewall', { 'default_value' => false }),
+  Boolean              $logrotate         = simplib::lookup('simp_options::logrotate', { 'default_value' => false }),
+  Boolean              $syslog            = simplib::lookup('simp_options::syslog', { 'default_value' => false }),
+  String[1]            $package_ensure    = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' })
 ) {
 
   if $dhcpd_conf {

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-dhcp",
-  "version": "6.4.0",
+  "version": "6.5.0",
   "author": "SIMP Team",
   "summary": "A Puppet module to automate configuration of DHCP",
   "license": "Apache-2.0",
@@ -14,7 +14,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 8.0.0 < 9.0.0"
+      "version_requirement": ">= 8.0.0 < 10.0.0"
     },
     {
       "name": "simp/iptables",
@@ -75,7 +75,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.22.1 < 8.0.0"
+      "version_requirement": ">= 7.0.0 < 9.0.0"
     }
   ]
 }

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -21,4 +21,4 @@ CONFIG:
   log_level: verbose
   type: aio
   synced_folder: disabled
-  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'puppet7') %>"
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'puppet8') %>"

--- a/spec/acceptance/nodesets/oel.yml
+++ b/spec/acceptance/nodesets/oel.yml
@@ -21,4 +21,4 @@ CONFIG:
   log_level: verbose
   type: aio
   synced_folder: disabled
-  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'puppet7') %>"
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'puppet8') %>"


### PR DESCRIPTION
* Drop use of Stdlib::Compat::Integer type
* Drop use of deprecated top-level facts
* Update gem dependencies
* Drop support for Puppet 6