### PR TITLE
Add clean-state noop acceptance test

### DIFF
--- a/spec/acceptance/suites/default/00_instances_spec.rb
+++ b/spec/acceptance/suites/default/00_instances_spec.rb
@@ -22,6 +22,22 @@ describe 'dhcpd' do
         # The simplest dhcpd.conf that won't give an error during restart
         let(:dhcp_config) { "subnet #{fact_on(host, 'networking.network').strip} netmask #{fact_on(host, 'networking.netmask')} { }" }
 
+        # Exercise noop from a clean state: on a fresh node the Sicura console
+        # previews the module with `puppet apply --noop`, which must not error.
+        # This runs before the applies below install/configure dhcpd, so it is
+        # the genuine fresh-node preview. A post-convergence noop check is
+        # omitted (`--noop --detailed-exitcodes` always exits 0). No package
+        # removal (as with fips/ssh) and, deliberately, no hieradata: the real
+        # applies set `simp_options::firewall => true` (which would pull in the
+        # simp_firewalld provider that is not noop-safe on EL8), so the noop
+        # runs a bare `include 'dhcp'` with firewall default-off -- exactly what
+        # the console previews on a fresh node.
+        context 'in noop mode from a clean state' do
+          it 'applies without errors in noop mode' do
+            apply_manifest_on(host, manifest, catch_failures: true, noop: true)
+          end
+        end
+
         it 'applies with no errors' do
           set_hieradata_on(host, hieradata)
           apply_manifest_on(host, manifest)


### PR DESCRIPTION
Exercises `puppet apply --noop` of the dhcp manifest from a clean state (before the suite's applies configure anything), guarding the Sicura console's fresh-node --noop preview. No package removal — matches the fips/ssh approach; deliberately no hieradata, so `simp_options::firewall` stays off and the EL8-unsafe simp_firewalld provider is not pulled in.